### PR TITLE
[#65812144] Jenkins script for running integration tests alone

### DIFF
--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+set -e
+bundle install --path "${HOME}/bundles/${JOB_NAME}"
+
+./scripts/generate_fog_conf_file.sh
+export FOG_RC=fog_integration_test.config
+bundle exec rake integration
+rm fog_integration_test.config


### PR DESCRIPTION
The ./jenkins.sh script runs all tests and publishes the Gem
on success, so is only useful for our primary Jenkins task.

This adds a secondary script for running the integration tests
on their own.
