### PR TITLE
[#66148596] Depend on latest vcloud-core version (0.0.6)

### DIFF
--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'fog', '>= 1.19.0'
-  s.add_runtime_dependency 'vcloud-core'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.6'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
We need Core::EdgeGateway.interfaces for the NatService
generator.
