### PR TITLE
[#66950180] Allow empty hashes for LoadBalancer services

### DIFF
--- a/lib/vcloud/schema/load_balancer_service.rb
+++ b/lib/vcloud/schema/load_balancer_service.rb
@@ -30,6 +30,7 @@ module Vcloud
     POOL_SERVICE_SECTION = {
       type: Hash,
       required: false,
+      allowed_empty: true,
       internals: {
         enabled: { type: 'boolean', required: false },
         port:    { type: 'string_or_number', required: false },
@@ -78,6 +79,7 @@ module Vcloud
     VIRTUAL_SERVER_SERVICE_PROFILE_ENTRY = {
       type: Hash,
       required: false,
+      allowed_empty: true,
       internals: {
         enabled: { type: 'boolean', required: false },
         port: { type: 'string_or_number', required: false },

--- a/spec/vcloud/edge_gateway/load_balancer_schema_validation_spec.rb
+++ b/spec/vcloud/edge_gateway/load_balancer_schema_validation_spec.rb
@@ -129,6 +129,48 @@ module Vcloud
         expect(validator.valid?).to be_true
       end
 
+      it "should validate ok if an empty pool service section is provided" do
+        input = {
+          pools: [
+            {
+              name: 'pool entry 1',
+              service: {
+                http: {},
+              },
+              members: [
+                { ip_address: "192.2.0.40" },
+                { ip_address: "192.2.0.41" },
+              ]
+            },
+          ],
+        }
+        validator = ConfigValidator.validate(:base, input, Vcloud::Schema::LOAD_BALANCER_SERVICE)
+        expect(validator.errors).to eq([])
+        expect(validator.valid?).to be_true
+      end
+
+      it "should validate ok if an empty virtual_server service_profile section is provided" do
+        input = {
+          pools: [{
+            name: 'pool-1',
+            service: { http: {} },
+            members: [ { ip_address: '10.10.10.10' } ],
+          }],
+          virtual_servers: [
+            {
+              name: 'virtual_server entry 1',
+              ip_address: "192.2.0.40",
+              network: "TestNetwork",
+              service_profiles: { http: {} },
+              pool: "pool-1",
+            },
+          ],
+        }
+        validator = ConfigValidator.validate(:base, input, Vcloud::Schema::LOAD_BALANCER_SERVICE)
+        expect(validator.errors).to eq([])
+        expect(validator.valid?).to be_true
+      end
+
       it "should be ok if no pools are specified" do
         input = {
           virtual_servers: []


### PR DESCRIPTION
All parameters underneath the per-service entries for
`virtual_server`->`service_profiles` and `pool`->`service` entries have
defaults, thereby allowing an empty hash as an argument.

The schema prevented this though, which this commit fixes.

Now you can specify:

```
pools:
  name: test-pool
  service:
    http: {}
virtual_servers:
  name: test-vs
  service_profile:
    http: {}
```

NB: This does not fix the 'allow nil' version, which would permit 'http:' vs 'http: {}' -- it's a more involved change, so I thought it best to keep it out of this PR.
