### PR TITLE
use Vcloud::QueryRunner instead of Vcloud::Query

### DIFF
--- a/spec/integration/edge_gateway/edge_gateway_services_spec.rb
+++ b/spec/integration/edge_gateway/edge_gateway_services_spec.rb
@@ -147,12 +147,13 @@ module Vcloud
 
       def get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(timestamp)
         vcloud_time = timestamp.strftime('%FT%T.000Z')
-        q = Query.new('task',
+        q = QueryRunner.new
+
+        q.run('task',
           :filter =>
             "name==networkConfigureEdgeGatewayServices;objectName==#{@edge_name};startDate=ge=#{vcloud_time}",
           :sortDesc => 'startDate',
         )
-        q.get_all_results
       end
 
     end

--- a/spec/integration/edge_gateway/load_balancer_service_spec.rb
+++ b/spec/integration/edge_gateway/load_balancer_service_spec.rb
@@ -190,12 +190,12 @@ module Vcloud
 
       def get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(timestamp)
         vcloud_time = timestamp.strftime('%FT%T.000Z')
-        q = Query.new('task',
+        q = QueryRunner.new
+        q.run('task',
           :filter =>
             "name==networkConfigureEdgeGatewayServices;objectName==#{@edge_name};startDate=ge=#{vcloud_time}",
           :sortDesc => 'startDate',
         )
-        q.get_all_results
       end
 
     end

--- a/spec/integration/edge_gateway/nat_service_spec.rb
+++ b/spec/integration/edge_gateway/nat_service_spec.rb
@@ -200,11 +200,11 @@ module Vcloud
 
       def get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(timestamp)
         vcloud_time = timestamp.strftime('%FT%T.000Z')
-        q = Query.new('task',
+        q = QueryRunner.new
+        q.run('task',
           :filter => "name==networkConfigureEdgeGatewayServices;objectName==#{@edge_name};startDate=ge=#{vcloud_time}",
           :sortDesc => 'startDate',
         )
-        q.get_all_results
       end
 
     end


### PR DESCRIPTION
Vcloud::Query and Vcloud::QueryRunner have been split so that the core code is in Query and the UI in QueryRunner. 

We've moved code to use Query runner where appropriate.

This will need to be applied after https://github.com/alphagov/vcloud-core/pull/14
