### PR TITLE
Use fog 1.21.0 (and vcloud-core 0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
 
   - Now uses the config loader and validator in vcloud-core rather than its own duplicate.
+  - Require fog v1.21 to allow use of FOG_VCLOUD_TOKEN via ENV as an alternative to a .fog file
 
 ## 0.2.2 (2014-03-05)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,63 @@ To configure an Edge Gateway:
 
     $ vcloud-configure-edge input.yaml
 
+### Credentials
+
+vCloud Edge Gateway is based around [fog]. To use it you'll need to give it credentials that allow it to talk to a VMware
+environment. Fog offers two ways to do this.
+
+#### 1. Create a `.fog` file containing your credentials
+
+To use this method, you need a `.fog` file in your home directory.
+
+For example:
+
+    test:
+      vcloud_director_username: 'username@org_name'
+      vcloud_director_password: 'password'
+      vcloud_director_host: 'host.api.example.com'
+
+Unfortunately current usage of fog requires the password in this file. Multiple sets of credentials can be specified in the fog file, using the following format:
+
+    test:
+      vcloud_director_username: 'username@org_name'
+      vcloud_director_password: 'password'
+      vcloud_director_host: 'host.api.example.com'
+
+    test2:
+      vcloud_director_username: 'username@org_name'
+      vcloud_director_password: 'password'
+      vcloud_director_host: 'host.api.vendor.net'
+
+You can then pass the `FOG_CREDENTIAL` environment variable at the start of your command. The value of the `FOG_CREDENTIAL` environment variable is the name of the credential set in your fog file which you wish to use.  For instance:
+
+    $ FOG_CREDENTIAL=test2 vcloud-configure-edge input.yaml
+
+To understand more about `.fog` files, visit the 'Credentials' section here => http://fog.io/about/getting_started.html.
+
+#### 2. Log on externally and supply your session token
+
+You can choose to log on externally by interacting independently with the API and supplying your session token to the
+tool by setting the `FOG_VCLOUD_TOKEN` ENV variable. This option reduces the risk footprint by allowing the user to
+store their credentials in safe storage. The default token lifetime is '30 minutes idle' - any activity extends the life by another 30 mins.
+
+A basic example of this would be the following:
+
+    curl
+       -D-
+       -d ''
+       -H 'Accept: application/*+xml;version=5.1' -u '<user>@<org>'
+       https://host.com/api/sessions
+
+This will prompt for your password.
+
+From the headers returned, select the header below
+
+     x-vcloud-authorization: AAAABBBBBCCCCCCDDDDDDEEEEEEFFFFF=
+
+Use token as ENV var FOG_VCLOUD_TOKEN
+
+    $ FOG_VCLOUD_TOKEN=AAAABBBBBCCCCCCDDDDDDEEEEEEFFFFF= vcloud-configure-edge input.yaml
 
 ## Contributing
 
@@ -374,3 +431,5 @@ Set environment variable `DEBUG=true` and/or `EXCON_DEBUG=true` to see Fog debug
 ### References
 
 * [vCloud Director Edge Gateway documentation](http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.admin.doc_51/GUID-ADE1DCAB-874F-45A9-9337-1E971DAC0F7D.html)
+
+[fog]: http://fog.io/

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.2'
 
-  s.add_runtime_dependency 'fog', '>= 1.19.0'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.10'
+  s.add_runtime_dependency 'fog', '>= 1.21.0'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.11'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
This allows the user to stop holding credentials in a .fog file.
- Note this relies on releasing of the vcloud-core gem 0.11.0 before being pulled down to master (https://github.com/alphagov/vcloud-core/pull/15)

This includes the raw fog changes only. To use it you'll need to get a session token, by externally logging in, and set that as FOG_VCLOUD_TOKEN ENV var. See https://github.com/fog/fog/pull/2705 for further detail.
