### PR TITLE
Reorder README to keep usage instructions together

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,6 @@ Use token as ENV var FOG_VCLOUD_TOKEN
 
     $ FOG_VCLOUD_TOKEN=AAAABBBBBCCCCCCDDDDDDEEEEEEFFFFF= vcloud-configure-edge input.yaml
 
-## Contributing
-
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
-
-
 ### Configure edge gateway services
 
 You can configure the following services on an existing edgegateway using
@@ -431,5 +422,14 @@ Set environment variable `DEBUG=true` and/or `EXCON_DEBUG=true` to see Fog debug
 ### References
 
 * [vCloud Director Edge Gateway documentation](http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.admin.doc_51/GUID-ADE1DCAB-874F-45A9-9337-1E971DAC0F7D.html)
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
 
 [fog]: http://fog.io/


### PR DESCRIPTION
The `Contributing` section was in the middle of the `Usage` instructions.

I've moved them to what I believe is the end of the usage section. 

/cc @annashipman 
