### PR TITLE
[#69911946] improve debugging section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,11 @@ cat edges.out | jq '
 You can find full configuration examples in the `examples` folder.
 
 
-### Debug output
+## Debugging
 
-Set environment variable `DEBUG=true` and/or `EXCON_DEBUG=true` to see Fog debug info.
+`export EXCON_DEBUG=true` - this will print out the API requests and responses.
+
+`export DEBUG=true` - this will show you the stack trace when there is an exception instead of just the message.
 
 ### References
 


### PR DESCRIPTION
This aligns the copy with the text in other tools, giving the user the reason to set these envvars.
