### PR TITLE
[#70500696] Use pessimistic version dependency for vcloud-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4 (2014-05-01)
+
+  - Use pessimistic version dependency for vcloud-core
+
 ## 0.2.3 (2014-04-22)
 
 Bugfixes:

--- a/lib/vcloud/edge_gateway/version.rb
+++ b/lib/vcloud/edge_gateway/version.rb
@@ -1,6 +1,6 @@
 module Vcloud
   module EdgeGateway
-    VERSION = '0.2.3'
+    VERSION = '0.2.4'
   end
 end
 

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.0.12'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
Use Ruby's pessimistic operator[1](http://guides.rubygems.org/patterns/#declaring_dependencies) for the version dependency on the
vcloud-core gem, which prevents us from installing a version of
vcloud-core with a greater minor version than the one specified.

In this case, only versions less than 0.1.0 will be installed.

This reinforces our policy of semantic versioning, whereby a minor
version bump may signify that changes in that versions are not backwards
compatible.

Also bump version to 0.2.4 to encourage people to download this version
in anticipation of breaking changes to come soon.
