### PR TITLE
[#69995588] Add explicit namespace to Query and QueryRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0 (2014-05-01)
+
+Features:
+
+  - Depend on version 0.2.0 of vcloud-core which introduces breaking changes to namespacing
+
 ## 0.2.4 (2014-05-01)
 
   - Use pessimistic version dependency for vcloud-core

--- a/lib/vcloud/edge_gateway/version.rb
+++ b/lib/vcloud/edge_gateway/version.rb
@@ -1,6 +1,6 @@
 module Vcloud
   module EdgeGateway
-    VERSION = '0.2.4'
+    VERSION = '0.3.0'
   end
 end
 

--- a/spec/integration/edge_gateway/edge_gateway_services_spec.rb
+++ b/spec/integration/edge_gateway/edge_gateway_services_spec.rb
@@ -140,7 +140,7 @@ module Vcloud
 
       def get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(timestamp)
         vcloud_time = timestamp.strftime('%FT%T.000Z')
-        q = QueryRunner.new
+        q = Vcloud::Core::QueryRunner.new
 
         q.run('task',
           :filter =>

--- a/spec/integration/edge_gateway/load_balancer_service_spec.rb
+++ b/spec/integration/edge_gateway/load_balancer_service_spec.rb
@@ -190,7 +190,7 @@ module Vcloud
 
       def get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(timestamp)
         vcloud_time = timestamp.strftime('%FT%T.000Z')
-        q = QueryRunner.new
+        q = Vcloud::Core::QueryRunner.new
         q.run('task',
           :filter =>
             "name==networkConfigureEdgeGatewayServices;objectName==#{@edge_name};startDate=ge=#{vcloud_time}",

--- a/spec/integration/edge_gateway/nat_service_spec.rb
+++ b/spec/integration/edge_gateway/nat_service_spec.rb
@@ -200,7 +200,7 @@ module Vcloud
 
       def get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(timestamp)
         vcloud_time = timestamp.strftime('%FT%T.000Z')
-        q = QueryRunner.new
+        q = Vcloud::Core::QueryRunner.new
         q.run('task',
           :filter => "name==networkConfigureEdgeGatewayServices;objectName==#{@edge_name};startDate=ge=#{vcloud_time}",
           :sortDesc => 'startDate',

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.0.12'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.2.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
Add the explicit namespacing to Query and QueryRunner in line with the
changes introduced in vcloud-core version 0.1.0, in which these classes
were moved under the Vcloud::Core namespace.

Also relates to [#70508876].

Depends on alphagov/vcloud-core#33.
