### PR TITLE
Bump/revert vcloud-core dep to 0.2.0

### DIFF
--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.1.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.2.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'


### PR DESCRIPTION
It seems that the dependency bump in 8b937c2 got eaten by my merge from
master in 855862a and 144e093. Sorry!
