### PR TITLE
[#71128590] Don't set healthcheck URI for non-HTTP checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Current (unreleased)
+
+Bugfixes:
+
+  - Don't set a load balancer healthcheck URI for healthchecks using protocols other than HTTP
+
 ## 0.4.0 (2014-05-12)
 
 Features:

--- a/lib/vcloud/edge_gateway/configuration_generator/load_balancer_service.rb
+++ b/lib/vcloud/edge_gateway/configuration_generator/load_balancer_service.rb
@@ -184,7 +184,7 @@ module Vcloud
         def generate_pool_healthcheck(protocol, input_pool_healthcheck_entry = nil)
           vcloud_pool_healthcheck_entry = {}
           vcloud_pool_healthcheck_entry[:Mode] = ( protocol == :https ) ? 'SSL' : protocol.to_s.upcase
-          vcloud_pool_healthcheck_entry[:Uri] = '/'
+          vcloud_pool_healthcheck_entry[:Uri] = ( protocol == :http ) ? '/' : ''
           vcloud_pool_healthcheck_entry[:HealthThreshold] = '2'
           vcloud_pool_healthcheck_entry[:UnhealthThreshold] = '3'
           vcloud_pool_healthcheck_entry[:Interval] = '5'
@@ -194,8 +194,14 @@ module Vcloud
             if input_pool_healthcheck_entry.key?(:protocol)
               vcloud_pool_healthcheck_entry[:Mode] = input_pool_healthcheck_entry[:protocol]
             end
-            if input_pool_healthcheck_entry.key?(:uri) and protocol == :http
-              vcloud_pool_healthcheck_entry[:Uri]  = input_pool_healthcheck_entry[:uri]
+            if input_pool_healthcheck_entry.key?(:uri)
+              if vcloud_pool_healthcheck_entry[:Mode] == 'HTTP'
+                vcloud_pool_healthcheck_entry[:Uri] = input_pool_healthcheck_entry[:uri]
+              else
+                raise "vCloud Director does not support healthcheck URI on protocols other than HTTP"
+              end
+            elsif vcloud_pool_healthcheck_entry[:Mode] != 'HTTP'
+                vcloud_pool_healthcheck_entry[:Uri] = ''
             end
             if input_pool_healthcheck_entry.key?(:health_threshold)
               vcloud_pool_healthcheck_entry[:HealthThreshold] =

--- a/spec/vcloud/edge_gateway/configuration_generator/data/load_balancer_http-output.yaml
+++ b/spec/vcloud/edge_gateway/configuration_generator/data/load_balancer_http-output.yaml
@@ -24,7 +24,7 @@
           HealthCheckPort: '',
           HealthCheck:
             {
-              Mode: "SSL", Uri: '/', HealthThreshold: '2', UnhealthThreshold: '3', Interval: '5', Timeout: '15'
+              Mode: "SSL", Uri: '', HealthThreshold: '2', UnhealthThreshold: '3', Interval: '5', Timeout: '15'
             }
         },
         {
@@ -35,7 +35,7 @@
           HealthCheckPort: '',
           HealthCheck:
             {
-              Mode: "TCP", Uri: '/', HealthThreshold: '2', UnhealthThreshold: '3', Interval: '5', Timeout: '15'
+              Mode: "TCP", Uri: '', HealthThreshold: '2', UnhealthThreshold: '3', Interval: '5', Timeout: '15'
             }
         }
       ],

--- a/spec/vcloud/edge_gateway/configuration_generator/data/load_balancer_https-output.yaml
+++ b/spec/vcloud/edge_gateway/configuration_generator/data/load_balancer_https-output.yaml
@@ -23,7 +23,7 @@
     :HealthCheckPort: ''
     :HealthCheck:
       :Mode: SSL
-      :Uri: '/'
+      :Uri: ''
       :HealthThreshold: '2'
       :UnhealthThreshold: '3'
       :Interval: '5'
@@ -35,7 +35,7 @@
     :HealthCheckPort: ''
     :HealthCheck:
       :Mode: TCP
-      :Uri: '/'
+      :Uri: ''
       :HealthThreshold: '2'
       :UnhealthThreshold: '3'
       :Interval: '5'

--- a/spec/vcloud/edge_gateway/configuration_generator/data/load_balancer_mixed_complex-output.yaml
+++ b/spec/vcloud/edge_gateway/configuration_generator/data/load_balancer_mixed_complex-output.yaml
@@ -10,7 +10,7 @@
     :HealthCheckPort: '8081'
     :HealthCheck:
       :Mode: TCP
-      :Uri: '/'
+      :Uri: ''
       :HealthThreshold: '2'
       :UnhealthThreshold: '3'
       :Interval: '5'
@@ -22,7 +22,7 @@
     :HealthCheckPort: '443'
     :HealthCheck:
       :Mode: TCP
-      :Uri: '/'
+      :Uri: ''
       :HealthThreshold: '2'
       :UnhealthThreshold: '3'
       :Interval: '5'
@@ -34,7 +34,7 @@
     :HealthCheckPort: ''
     :HealthCheck:
       :Mode: TCP
-      :Uri: '/'
+      :Uri: ''
       :HealthThreshold: '2'
       :UnhealthThreshold: '3'
       :Interval: '5'

--- a/spec/vcloud/edge_gateway/edge_gateway_configuration_spec.rb
+++ b/spec/vcloud/edge_gateway/edge_gateway_configuration_spec.rb
@@ -659,7 +659,7 @@ module Vcloud
               :HealthCheckPort=>"",
               :HealthCheck=>{
                 :Mode=>"SSL",
-                :Uri=>"/",
+                :Uri=>"",
                 :HealthThreshold=>"2",
                 :UnhealthThreshold=>"3",
                 :Interval=>"5",
@@ -673,7 +673,7 @@ module Vcloud
               :HealthCheckPort=>"",
               :HealthCheck=>{
                 :Mode=>"TCP",
-                :Uri=>"/",
+                :Uri=>"",
                 :HealthThreshold=>"2",
                 :UnhealthThreshold=>"3",
                 :Interval=>"5",
@@ -844,7 +844,7 @@ module Vcloud
               :HealthCheckPort=>"",
               :HealthCheck=>{
                 :Mode=>"SSL",
-                :Uri=>"/",
+                :Uri=>"",
                 :HealthThreshold=>"2",
                 :UnhealthThreshold=>"3",
                 :Interval=>"5",
@@ -858,7 +858,7 @@ module Vcloud
               :HealthCheckPort=>"",
               :HealthCheck=>{
                 :Mode=>"TCP",
-                :Uri=>"/",
+                :Uri=>"",
                 :HealthThreshold=>"2",
                 :UnhealthThreshold=>"3",
                 :Interval=>"5",
@@ -1030,7 +1030,7 @@ module Vcloud
               :HealthCheckPort=>"",
               :HealthCheck=>{
                 :Mode=>"SSL",
-                :Uri=>"/",
+                :Uri=>"",
                 :HealthThreshold=>"2",
                 :UnhealthThreshold=>"3",
                 :Interval=>"5",
@@ -1044,7 +1044,7 @@ module Vcloud
               :HealthCheckPort=>"",
               :HealthCheck=>{
                 :Mode=>"TCP",
-                :Uri=>"/",
+                :Uri=>"",
                 :HealthThreshold=>"2",
                 :UnhealthThreshold=>"3",
                 :Interval=>"5",


### PR DESCRIPTION
Don't set a healthcheck URI for non-HTTP load balancer healthchecks.

In vCloud Director version 5.1 and 5.5, VMWare does not support a
healthcheck URI for SSL healthchecks[1]. In vCloud Director version 5.5,
a load balancer will refuse connections if a health check URL is set for
an SSL healthcheck.

TCP healthchecks obviously do not support a healthcheck URI given they
do not operate at layer 7.

This also fixes an issue related to ecfba39; that commit checks for a pool
service protocol of HTTP and sets the healthcheck URL accordingly. The
changes there did not however account for configurations where the pool
uses HTTP as the service protocol but TCP for the healthcheck.

The logic here is necessarily complex because we deal with:
- defined configuration versus the default
- healthcheck protocols (default or defined) versus service protocols

Raise an exception if a healthcheck URI is specified for a load
balancer healthcheck using any protocol other than HTTP.

Also adds tests for the above behaviour:
- Add a spec test to ensure that that the default URI for healthchecks
  using the HTTP protocol is '/'. The behaviour we are testing for was
  implemented in e9c524b.
- Add a spec test to ensure that that the default URI for healthchecks
  using the HTTPS protocol is ''. The behaviour we are testing for was
  implemented in e9c524b.
- Add a spec test to ensure that that the default URI for healthchecks
  using the TCP protocol, when the load balancer service protocol is
  'HTTP', is ''. The behaviour we are testing for was implemented in
  this same commit.
- Add a spec test that expects an exception to be raised if we attempt
  to define a healthcheck URI for a non-HTTP healthcheck. Only HTTP
  healthchecks support a healthcheck URI. The behaviour we are testing
  for was implemented in this same commit.

[1]:
http://pubs.vmware.com/vcd-55/topic/com.vmware.vcloud.admin.doc_55/GUID-C12B3954-155F-48AF-9855-E0DE026752D0.html
