### PR TITLE
Change invocation of EdgeGateway::Configure

### DIFF
--- a/bin/vcloud-configure-edge
+++ b/bin/vcloud-configure-edge
@@ -9,10 +9,11 @@ class App
 
   main do |config_file|
     if options['template-vars']
-      Vcloud::EdgeGateway::Configure.new.update(config_file, options['template-vars'])
+      vse = Vcloud::EdgeGateway::Configure.new(config_file, options['template-vars'])
     else
-      Vcloud::EdgeGateway::Configure.new.update(config_file)
+      vse = Vcloud::EdgeGateway::Configure.new(config_file)
     end
+    vse.update
   end
 
   arg :config_file

--- a/lib/vcloud/edge_gateway/configure.rb
+++ b/lib/vcloud/edge_gateway/configure.rb
@@ -4,19 +4,18 @@ module Vcloud
   module EdgeGateway
     class Configure
 
-      def initialize
-        @config_loader = Vcloud::Core::ConfigLoader.new
+      def initialize(config_file = nil, vars_file = nil)
+        config_loader = Vcloud::Core::ConfigLoader.new
+        @local_config = config_loader.load_config(config_file, Vcloud::EdgeGateway::Schema::EDGE_GATEWAY_SERVICES, vars_file)
       end
 
-      def update(config_file = nil, vars_file = nil)
-        local_config = @config_loader.load_config(config_file, Vcloud::EdgeGateway::Schema::EDGE_GATEWAY_SERVICES, vars_file)
-
-        edge_gateway = Vcloud::Core::EdgeGateway.get_by_name local_config[:gateway]
+      def update
+        edge_gateway = Vcloud::Core::EdgeGateway.get_by_name @local_config[:gateway]
         remote_config = edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
         edge_gateway_interface_list = edge_gateway.interfaces
 
         proposed_config = Vcloud::EdgeGateway::EdgeGatewayConfiguration.new(
-          local_config,
+          @local_config,
           remote_config,
           edge_gateway_interface_list
         )

--- a/spec/integration/edge_gateway/edge_gateway_services_spec.rb
+++ b/spec/integration/edge_gateway/edge_gateway_services_spec.rb
@@ -39,7 +39,7 @@ module Vcloud
         it "should only create one edgeGateway update task when updating the configuration" do
           start_time = Time.now.getutc
           task_list_before_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
-          EdgeGateway::Configure.new.update(@initial_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_config_file, @vars_config_file).update
           task_list_after_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
           expect(task_list_after_update.size - task_list_before_update.size).to be(1)
         end
@@ -55,7 +55,7 @@ module Vcloud
         it "should not update the EdgeGateway again if the config hasn't changed" do
           start_time = Time.now.getutc
           task_list_before_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
-          EdgeGateway::Configure.new.update(@initial_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_config_file, @vars_config_file).update
           task_list_after_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
           expect(task_list_after_update.size - task_list_before_update.size).to be(0)
         end
@@ -63,7 +63,7 @@ module Vcloud
         it "should only create one additional edgeGateway update task when adding the LoadBalancer config" do
           start_time = Time.now.getutc
           task_list_before_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
-          EdgeGateway::Configure.new.update(@adding_load_balancer_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@adding_load_balancer_config_file, @vars_config_file).update
           task_list_after_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
           expect(task_list_after_update.size - task_list_before_update.size).to be(1)
         end
@@ -71,7 +71,7 @@ module Vcloud
         it "should not update the EdgeGateway again if we reapply the 'adding load balancer' config" do
           start_time = Time.now.getutc
           task_list_before_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
-          EdgeGateway::Configure.new.update(@adding_load_balancer_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@adding_load_balancer_config_file, @vars_config_file).update
           task_list_after_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
           expect(task_list_after_update.size - task_list_before_update.size).to be(0)
         end

--- a/spec/integration/edge_gateway/firewall_service_spec.rb
+++ b/spec/integration/edge_gateway/firewall_service_spec.rb
@@ -44,7 +44,7 @@ module Vcloud
 
         it "should only need to make one call to Core::EdgeGateway.update_configuration" do
           expect_any_instance_of(Core::EdgeGateway).to receive(:update_configuration).exactly(1).times.and_call_original
-          EdgeGateway::Configure.new.update(@initial_firewall_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_firewall_config_file, @vars_config_file).update
         end
 
         it "should have configured at least one firewall rule" do
@@ -60,7 +60,7 @@ module Vcloud
 
         it "and then should not configure the firewall service if updated again with the same configuration (idempotency)" do
           expect(Vcloud::Core.logger).to receive(:info).with('EdgeGateway::Configure.update: Configuration is already up to date. Skipping.')
-          EdgeGateway::Configure.new.update(@initial_firewall_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_firewall_config_file, @vars_config_file).update
         end
 
         it "ConfigurationDiffer should return empty if local and remote firewall configs match" do
@@ -132,10 +132,10 @@ module Vcloud
       context "Specific FirewallService update tests" do
 
         it "should have the same rule order as the input rule order" do
-          EdgeGateway::Configure.new.update(
+          EdgeGateway::Configure.new(
             IntegrationHelper.fixture_file('firewall_rule_order_test.yaml.mustache'),
             @vars_config_file
-          )
+          ).update
           remote_rules = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration][:FirewallService][:FirewallRule]
           remote_descriptions_list = remote_rules.map {|rule| rule[:Description]}
           expect(remote_descriptions_list).

--- a/spec/integration/edge_gateway/load_balancer_service_spec.rb
+++ b/spec/integration/edge_gateway/load_balancer_service_spec.rb
@@ -48,7 +48,7 @@ module Vcloud
         it "should only make one EdgeGateway update task, to minimise EdgeGateway reload events" do
           start_time = Time.now.getutc
           task_list_before_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
-          EdgeGateway::Configure.new.update(@initial_load_balancer_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_load_balancer_config_file, @vars_config_file).update
           task_list_after_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
           expect(task_list_after_update.size - task_list_before_update.size).to be(1)
         end
@@ -90,7 +90,7 @@ module Vcloud
         it "should not then configure the LoadBalancerService if updated again with the same configuration" do
           expect(Vcloud::Core.logger).
             to receive(:info).with('EdgeGateway::Configure.update: Configuration is already up to date. Skipping.')
-          EdgeGateway::Configure.new.update(@initial_load_balancer_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_load_balancer_config_file, @vars_config_file).update
         end
 
       end
@@ -99,7 +99,7 @@ module Vcloud
 
         it "should be able to configure with no pools and virtual_servers" do
           config_file = IntegrationHelper.fixture_file('load_balancer_empty.yaml.mustache')
-          EdgeGateway::Configure.new.update(config_file, @vars_config_file)
+          EdgeGateway::Configure.new(config_file, @vars_config_file).update
           edge_config = @edge_gateway.vcloud_attributes[:Configuration]
           remote_vcloud_config = edge_config[:EdgeGatewayServiceConfiguration][:LoadBalancerService]
           expect(remote_vcloud_config[:Pool].size).to be == 0
@@ -108,7 +108,7 @@ module Vcloud
 
         it "should be able to configure with a single Pool and no VirtualServers" do
           config_file = IntegrationHelper.fixture_file('load_balancer_single_pool.yaml.mustache')
-          EdgeGateway::Configure.new.update(config_file, @vars_config_file)
+          EdgeGateway::Configure.new(config_file, @vars_config_file).update
           edge_config = @edge_gateway.vcloud_attributes[:Configuration]
           remote_vcloud_config = edge_config[:EdgeGatewayServiceConfiguration][:LoadBalancerService]
           expect(remote_vcloud_config[:Pool].size).to be == 1
@@ -116,13 +116,13 @@ module Vcloud
 
         it "should raise an error when trying configure with a single VirtualServer, and no pool mentioned" do
           config_file = IntegrationHelper.fixture_file('load_balancer_single_virtual_server_missing_pool.yaml.mustache')
-          expect { EdgeGateway::Configure.new.update(config_file, @vars_config_file) }.
+          expect { EdgeGateway::Configure.new(config_file, @vars_config_file).update }.
             to raise_error('Supplied configuration does not match supplied schema')
         end
 
         it "should raise an error when trying configure with a single VirtualServer, with an unconfigured pool" do
           config_file = IntegrationHelper.fixture_file('load_balancer_single_virtual_server_invalid_pool.yaml.mustache')
-          expect { EdgeGateway::Configure.new.update(config_file, @vars_config_file) }.
+          expect { EdgeGateway::Configure.new(config_file, @vars_config_file).update }.
             to raise_error(
               'Load balancer virtual server integration-test-vs-1 does not have a valid backing pool.'
             )

--- a/spec/integration/edge_gateway/nat_service_spec.rb
+++ b/spec/integration/edge_gateway/nat_service_spec.rb
@@ -47,7 +47,7 @@ module Vcloud
         it "should only make one EdgeGateway update task, to minimise EdgeGateway reload events" do
           start_time = Time.now.getutc
           task_list_before_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
-          EdgeGateway::Configure.new.update(@initial_nat_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_nat_config_file, @vars_config_file).update
           task_list_after_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
           expect(task_list_after_update.size - task_list_before_update.size).to be(1)
         end
@@ -72,7 +72,7 @@ module Vcloud
 
         it "and then should not configure the firewall service if updated again with the same configuration (idempotency)" do
           expect(Vcloud::Core.logger).to receive(:info).with('EdgeGateway::Configure.update: Configuration is already up to date. Skipping.')
-          EdgeGateway::Configure.new.update(@initial_nat_config_file, @vars_config_file)
+          EdgeGateway::Configure.new(@initial_nat_config_file, @vars_config_file).update
         end
 
       end
@@ -118,10 +118,10 @@ module Vcloud
             original_ip: @int_net_ip,
           })
 
-          EdgeGateway::Configure.new.update(
+          EdgeGateway::Configure.new(
             IntegrationHelper.fixture_file('hairpin_nat_config.yaml.mustache'),
             vars_file
-          )
+          ).update
 
           edge_gateway = Vcloud::Core::EdgeGateway.get_by_name(@edge_name)
           nat_service = edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration][:NatService]
@@ -148,10 +148,10 @@ module Vcloud
           })
 
           expect {
-            EdgeGateway::Configure.new.update(
+            EdgeGateway::Configure.new(
               IntegrationHelper.fixture_file('nat_config.yaml.mustache'),
               vars_file
-            )
+            ).update
           }.to raise_error("unable to find gateway network interface with id #{random_network_id}")
         end
       end


### PR DESCRIPTION
Move the config and template arguments to the initialiser so that:
- It behaves more like a class than a module. So that you instantiate it
  with a config and then call update on that object, which feels more
  natural than doing `foo.new.update()`.
- We can perform schema validation early and separately from applying the
  update. Which will be particulary useful when we expose a `--validate`
  argument in [#69717072].
