### PR TITLE
[Fixes #71223820] Refactor update_required?

### DIFF
--- a/lib/vcloud/edge_gateway/edge_gateway_configuration.rb
+++ b/lib/vcloud/edge_gateway/edge_gateway_configuration.rb
@@ -16,10 +16,13 @@ module Vcloud
       def generate_new_config(local_config, remote_config, edge_gateway_interfaces)
         new_config = { }
 
-        firewall_service_config = EdgeGateway::ConfigurationGenerator::FirewallService.new.generate_fog_config(local_config[:firewall_service])
+        firewall_service_config =
+          EdgeGateway::ConfigurationGenerator::FirewallService.new.
+            generate_fog_config(local_config[:firewall_service])
 
         unless firewall_service_config.nil?
-          differ = EdgeGateway::FirewallConfigurationDiffer.new(firewall_service_config, remote_config[:FirewallService])
+          differ = EdgeGateway::FirewallConfigurationDiffer.
+            new(firewall_service_config, remote_config[:FirewallService])
           unless differ.diff.empty?
             new_config[:FirewallService] = firewall_service_config
           end


### PR DESCRIPTION
Refactor `Vcloud::EdgeGateway::EdgeGatewayConfiguration.update_required?` so that it does not modify `Vcloud::EdgeGateway::EdgeGatewayConfiguration.config`, which is potentially confusiong for a method that by convention should only return a boolean.

The logic in `update_required?` has moved to the `config()` method, which has been renamed to `generate_new_config()` to make the name more descriptive.

I have also removed `local_config`, `remote_config`, and `edge_gateway_interfaces` as instance variables; these are now passed to `generate_new_config()`.

`generate_new_config()` is now a private method so that we can change our internal interfaces more easily without worrying about making what would have been breaking changes; it's also called immediately from
the `initialize()` method.

`generate_new_config()` does not update the `@config` instance variable, rather it updates a `new_config` method variable which it then returns. I've added an `attr_reader` for the `@config` instance variable
accordingly.
