### PR TITLE
[#71926812] Add Pry as a development dependency

### DIFF
--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'vcloud-core', '~> 0.2.0'
   s.add_runtime_dependency 'hashdiff'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubocop'


### PR DESCRIPTION
[Pry](http://pryrepl.org/) is a Ruby shell and is very useful for debugging.

You can use Pry by specifying `RUBYOPT='-r pry'` when running the vCloud Tools CLI commands and by adding breakpoints in your code, for example:

```
binding.pry
```

Hitting ^D will exit the shell and resume code execution after the break point.
