### PR TITLE
Restrict simplecov to unit tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,26 +1,31 @@
-require 'simplecov'
 require 'support/integration_helper'
 
-SimpleCov.profiles.define 'gem' do
-  add_filter '/spec/'
-  add_filter '/features/'
-  add_filter '/vendor/'
+if ENV['COVERAGE']
+  require 'simplecov'
 
-  add_group 'Libraries', '/lib/'
+  SimpleCov.profiles.define 'gem' do
+    add_filter '/spec/'
+    add_filter '/features/'
+    add_filter '/vendor/'
+
+    add_group 'Libraries', '/lib/'
+  end
+
+  SimpleCov.start 'gem'
 end
-
-SimpleCov.start 'gem'
 
 require 'bundler/setup'
 require 'vcloud/edge_gateway'
 
 
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  # do not change the coverage percentage, instead add more unit tests to fix coverage failures.
-  if SimpleCov.result.covered_percent < 90
-    print "ERROR::BAD_COVERAGE\n"
-    print "Coverage is less than acceptable limit(90%). Please add more tests to improve the coverage\n"
-    exit(1)
+if ENV['COVERAGE']
+  SimpleCov.at_exit do
+    SimpleCov.result.format!
+    # do not change the coverage percentage, instead add more unit tests to fix coverage failures.
+    if SimpleCov.result.covered_percent < 90
+      print "ERROR::BAD_COVERAGE\n"
+      print "Coverage is less than acceptable limit(90%). Please add more tests to improve the coverage\n"
+      exit(1)
+    end
   end
 end


### PR DESCRIPTION
The addition of Vcloud::EdgeGateway::Cli, which was covered by unit tests,
caused the integration tests to fail on low coverage because they are run
from a separate rake task.

Use the COVERAGE environment variable, already set by the Rakefile for unit
tests, to restrict coverage checking. This aligns it with how vcloud-core
works.
