### PR TITLE
Update Jenkins job to `git clone` test parameters

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,14 @@
 #!/bin/bash -x
 set -e
+
+git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec rake
+
+# Obtain the integration test parameters
+git clone git@github.gds:gds/vcloud-tools-testing-config.git
+mv vcloud-tools-testing-config/vcloud_tools_testing_config.yaml spec/integration/
+rm -rf vcloud-tools-testing-config
 
 RUBYOPT="-r ./tools/fog_credentials" bundle exec rake integration
 

--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -x
 set -e
+
+git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
+
+# Obtain the integration test parameters
+git clone git@github.gds:gds/vcloud-tools-testing-config.git
+mv vcloud-tools-testing-config/vcloud_tools_testing_config.yaml spec/integration/
+rm -rf vcloud-tools-testing-config
 
 RUBYOPT="-r ./tools/fog_credentials" bundle exec rake integration


### PR DESCRIPTION
Update `jenkins_integration_tests.sh` so that it retrieves test parameters used for integration tests from a git repository in Github Entreprise.

This allows us to access the test parameters using the vCloud Tools Tester gem, which is supported as of
e03b40b50d0ac1e854024e1c00f6e8dcd675eea3.
