### PR TITLE
Remove open rescue from Cli tests

### DIFF
--- a/spec/vcloud/edge_gateway/cli_spec.rb
+++ b/spec/vcloud/edge_gateway/cli_spec.rb
@@ -16,9 +16,6 @@ class CommandRun
     rescue SystemExit => e
       # Capture exit(n) value.
       @exitstatus = e.status
-    rescue
-      # Uncaught exception which would normally exit 1.
-      @exitstatus = 1
     end
 
     @stdout = out.string.strip


### PR DESCRIPTION
This isn't actually as useful as I first planned. In most cases it obscures
the real exception when you're writing new tests and they fail. Because this
is a unit test and we're mocking the other classes that get called we'd
never expect to hit this. If we need to test the end-to-end behaviour it
would probably belong in an integration tests, rather than here.
