### PR TITLE
[#71591898] Link to schemas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,9 +423,14 @@ cat edges.out | jq '
       '
 ```
 
-### Full configuration examples
+### Full configuration examples and schemas
 
-You can find full configuration examples in the `examples` folder.
+Full configuration examples are in the [`examples/`][examples] folder.
+
+Configuration schemas are in [`lib/vcloud/edge_gateway/schema/`][schema].
+
+[examples]: /examples
+[schema]: /lib/vcloud/edge_gateway/schema
 
 ## The vCloud API
 


### PR DESCRIPTION
So that users can determine the rules of a valid configuration. And add a
clickable link to the examples, while we're here. GitHub's magic markdown
will determine the correct path e.g. `/tree/master`
