### PR TITLE
Move hashdiff require to class that's using it

### DIFF
--- a/lib/vcloud/edge_gateway/configuration_differ.rb
+++ b/lib/vcloud/edge_gateway/configuration_differ.rb
@@ -1,3 +1,5 @@
+require 'hashdiff'
+
 module Vcloud
   module EdgeGateway
     class ConfigurationDiffer
@@ -25,5 +27,4 @@ module Vcloud
 
     end
   end
-
 end

--- a/lib/vcloud/edge_gateway/configure.rb
+++ b/lib/vcloud/edge_gateway/configure.rb
@@ -1,5 +1,3 @@
-require 'hashdiff'
-
 module Vcloud
   module EdgeGateway
     class Configure


### PR DESCRIPTION
This third-party gem is used by ConfigurationDiffer not Configure.

Also remove a stray newline from the class that it's going to.
