### PR TITLE
Add some rdoc comments to ConfigurationDiffer

### DIFF
--- a/lib/vcloud/edge_gateway/configuration_differ.rb
+++ b/lib/vcloud/edge_gateway/configuration_differ.rb
@@ -2,6 +2,7 @@ require 'hashdiff'
 
 module Vcloud
   module EdgeGateway
+    # This class is inherited by service-specific differ classes.
     class ConfigurationDiffer
 
         def initialize local, remote
@@ -21,6 +22,9 @@ module Vcloud
           strip_fields_for_differ_to_ignore(@remote) unless @remote.nil?
         end
 
+        # This class is typically overridden by the inheriting class to
+        # remove fields that are specific to that service e.g. the IDs of
+        # firewall rules.
         def strip_fields_for_differ_to_ignore(config)
           config
         end


### PR DESCRIPTION
I double-took at the method which returns an unmodified object. Add a
comment to make it clearer why it's there.
