### PR TITLE
[#72424964] Disable `should` syntax in Rspec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,11 @@ require 'bundler/setup'
 require 'vcloud/edge_gateway'
 require 'vcloud/tools/tester'
 
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end
 
 if ENV['COVERAGE']
   SimpleCov.at_exit do


### PR DESCRIPTION
`should` syntax is deprecated as of Rspec version 3.0 and the previous
commit converts all of our tests to use `expect` for consistency.

To prevent regressions, this change disables `should` syntax for this
gem.

---

Please note, we weren't using the `should` syntax anywhere in this gem so there was nothing to convert to use `expect` (as was the case with other gems).
