### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.1 (2014-06-13)
+
+Bugfixes:
+
+  - The NAT schema incorrectly allowed 'tcp+udp' as a valid protocol which would
+  lead to a HTTP 500 response from the API. The schema now accepts the correct value,
+  'tcpudp'. Thanks to @abridgett for discovering and fixing this.
+
 ## 1.0.0 (2014-06-04)
 
 Features:

--- a/lib/vcloud/edge_gateway/version.rb
+++ b/lib/vcloud/edge_gateway/version.rb
@@ -1,6 +1,6 @@
 module Vcloud
   module EdgeGateway
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end
 


### PR DESCRIPTION
Bump the version to 1.0.1 and update the CHANGELOG in reference to
@abridgett's fix for NAT rules using both the TCP and UDP protocols.
