### PR TITLE
[#67916012] Use new TestSetup interface to access test params

### DIFF
--- a/spec/integration/edge_gateway/configure_firewall_spec.rb
+++ b/spec/integration/edge_gateway/configure_firewall_spec.rb
@@ -6,7 +6,7 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestParameters.new(config_file)
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
       @files_to_delete = []
     end
 

--- a/spec/integration/edge_gateway/configure_load_balancer_spec.rb
+++ b/spec/integration/edge_gateway/configure_load_balancer_spec.rb
@@ -6,7 +6,7 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestParameters.new(config_file)
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
       @files_to_delete = []
     end
 

--- a/spec/integration/edge_gateway/configure_multiple_services_spec.rb
+++ b/spec/integration/edge_gateway/configure_multiple_services_spec.rb
@@ -6,7 +6,7 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestParameters.new(config_file)
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
       @files_to_delete = []
     end
 

--- a/spec/integration/edge_gateway/configure_nat_spec.rb
+++ b/spec/integration/edge_gateway/configure_nat_spec.rb
@@ -6,7 +6,7 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestParameters.new(config_file)
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
       @files_to_delete = []
     end
 

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.2.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.5.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.23.0'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
-  s.add_development_dependency 'vcloud-tools-tester', '0.0.5'
+  s.add_development_dependency 'vcloud-tools-tester', '0.1.0'
 end
 


### PR DESCRIPTION
**DEPENDS ON https://github.com/gds-operations/vcloud-tools-tester/pull/16**

As of version 0.1.0 of the vCloud Tools Tester gem, we must use the
`Vcloud::Tools::Tester::TestSetup#test_params` method to retrieve test
parameters.

In doing so, that gem will ensure that the network fixtures are correct
in the vCloud organization that the integration tests run against.

Also, update the gemspec file to reflect this.

---

Note that I've intentionally left the `expected_user_params` argument
for `TestSetup#new` empty; this is new functionality that was added in
vCloud Tools Tester version 0.1.0 and is outside the scope of the
current story.
