### PR TITLE
[#72866380] Specify the required user-defined test params

### DIFF
--- a/spec/integration/edge_gateway/configure_firewall_spec.rb
+++ b/spec/integration/edge_gateway/configure_firewall_spec.rb
@@ -6,7 +6,13 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+      required_user_params = [
+        "edge_gateway",
+        "provider_network_id",
+        "provider_network_ip",
+      ]
+
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
       @files_to_delete = []
     end
 

--- a/spec/integration/edge_gateway/configure_load_balancer_spec.rb
+++ b/spec/integration/edge_gateway/configure_load_balancer_spec.rb
@@ -6,7 +6,13 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+      required_user_params = [
+        "edge_gateway",
+        "provider_network_id",
+        "provider_network_ip",
+      ]
+
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
       @files_to_delete = []
     end
 

--- a/spec/integration/edge_gateway/configure_multiple_services_spec.rb
+++ b/spec/integration/edge_gateway/configure_multiple_services_spec.rb
@@ -6,7 +6,13 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+      required_user_params = [
+        "edge_gateway",
+        "provider_network_id",
+        "provider_network_ip",
+      ]
+
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
       @files_to_delete = []
     end
 

--- a/spec/integration/edge_gateway/configure_nat_spec.rb
+++ b/spec/integration/edge_gateway/configure_nat_spec.rb
@@ -6,7 +6,16 @@ module Vcloud
 
     before(:all) do
       config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+      required_user_params = [
+        "edge_gateway",
+        "network_1",
+        "network_1_id",
+        "network_1_ip",
+        "provider_network_id",
+        "provider_network_ip",
+      ]
+
+      @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
       @files_to_delete = []
     end
 


### PR DESCRIPTION
By specifying the user-defined test parameters we require for each test,
vCloud Tools Tester will fail fast if these parameters are not defined.
