### PR TITLE
[#74382904] Depend on vCloud Core 0.6.0; release new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 (2014-07-14)
+
+Update the dependency on vCloud Core to version 0.6.0 to avoid dependency issues._
+
 ## 1.0.1 (2014-06-13)
 
 Bugfixes:

--- a/lib/vcloud/edge_gateway/version.rb
+++ b/lib/vcloud/edge_gateway/version.rb
@@ -1,6 +1,6 @@
 module Vcloud
   module EdgeGateway
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
   end
 end
 

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.5.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.6.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Bump the dependency on vCloud Core 0.6.0 to avoid dependency issues.

**DEPENDS ON https://github.com/gds-operations/vcloud-core/pull/91**
