### PR TITLE
[#68989754] Update vcloud-core for vcloud-login utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## UNRELEASED (2014-XX-XX)
+
+Update to vCloud Core 0.7.0 for the following:
+
+  - New vcloud-login tool for fetching session tokens without the need to
+    store your password in a plaintext FOG_RC file.
+  - Deprecate the use of :vcloud_director_password in a plaintext FOG_RC
+    file. A warning will be printed to STDERR at load time. Please use
+    vcloud-login instead.
+
 ## 1.0.2 (2014-07-14)
 
 Update the dependency on vCloud Core to version 0.6.0 to avoid dependency issues._

--- a/README.md
+++ b/README.md
@@ -32,41 +32,7 @@ be re-used between environments:
 
 ## Credentials
 
-vCloud Edge Gateway is based around [fog](http://fog.io/). To use it you'll need to give it
-credentials that allow it to talk to a vCloud Director environment.
-
-1. Create a '.fog' file in your home directory.
-
-  For example:
-
-      test_credentials:
-        vcloud_director_host: 'host.api.example.com'
-        vcloud_director_username: 'username@org_name'
-        vcloud_director_password: ''
-
-2. Obtain a session token. First, curl the API:
-
-        curl -D- -d '' \
-            -H 'Accept: application/*+xml;version=5.1' -u '<username>@<org_name>' \
-            https://<host.api.example.com>/api/sessions
-
-  This will prompt for your password.
-
-  From the headers returned, the value of the `x-vcloud-authorization` header is your
-  session token, and this will be valid for 30 minutes idle - any activity will extend
-  its life by another 30 minutes.
-
-3. Specify your credentials and session token at the beginning of the command. For example:
-
-        FOG_CREDENTIAL=test_credentials \
-            FOG_VCLOUD_TOKEN=AAAABBBBBCCCCCCDDDDDDEEEEEEFFFFF= \
-            vcloud-edge-configure input.yaml
-
-  You may find it easier to export one or both of the values as environment variables.
-
-  **NB** It is also possible to sidestep the need for the session token by saving your
-  password in the fog file. This is **not recommended**.
-
+Please see the [vcloud-tools usage documentation](http://gds-operations.github.io/vcloud-tools/usage/).
 
 ### Configure edge gateway services
 

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'fog', '>= 1.21.0'
-  s.add_runtime_dependency 'vcloud-core', '~> 0.6.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.7.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Makes the new `vcloud-login` utility available and deprecates the use of
plaintext passwords in FOG_RC. Documentation about credentials is now
centralised.
