### PR TITLE
[#70162466] Remove only executed references to fog

### DIFF
--- a/lib/vcloud/edge_gateway.rb
+++ b/lib/vcloud/edge_gateway.rb
@@ -1,7 +1,6 @@
 require 'vcloud/edge_gateway/version'
 
 require 'vcloud/core'
-require 'vcloud/fog'
 
 require 'vcloud/edge_gateway/schema/nat_service'
 require 'vcloud/edge_gateway/schema/firewall_service'

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'fog', '>= 1.21.0'
   s.add_runtime_dependency 'vcloud-core', '~> 0.7.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
This gem doesn't directly access the fog stuff in Core. It talks about it a lot though.

This works fine with the released vCloud Core, because `vcloud/core` includes `vcloud/fog` anyway, so no need to wait for the rest of the changes coming to make this one.
