### PR TITLE
Remove developer environment-specific ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,9 @@
 *.gem
 *.rbc
-*.swp
-*.un~
-vcloud_env.sh
-replace_variables.sh
 /.bundle/
 /.ruby-version
 /Gemfile.lock
-/bundle/
 /pkg/
-vendor/
 coverage/
 spec/integration/vcloud_tools_testing_config.yaml
-results.html
 fog_integration_test.config
-.idea


### PR DESCRIPTION
Gitignores should be releated to the project, not individual developers' set up. The latter should be in a global gitignore.
