### PR TITLE
Bump vcloud-core dep to 0.11.0 and release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0 (2014-09-11)
+
+  - Upgrade dependency on vCloud Core to 0.11.0 which prevents plaintext
+    passwords in FOG_RC. Please use tokens via vcloud-login as per
+    the documentation: http://gds-operations.github.io/vcloud-tools/usage/
+
 ## 1.1.0 (2014-08-11)
 
 Update to vCloud Core 0.10.0 for the following:

--- a/lib/vcloud/edge_gateway/version.rb
+++ b/lib/vcloud/edge_gateway/version.rb
@@ -1,6 +1,6 @@
 module Vcloud
   module EdgeGateway
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end
 

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 0.10.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.11.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Major change:
- plaintext passwords are no longer permissible in FOG_RC
  See http://gds-operations.github.io/vcloud-tools/usage/
