### PR TITLE
Fix test time sensitivity when checking tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+Update vCloud Core to 0.14.0 to improve speed of integration tests.
+
 ## 1.3.0 (2014-10-14)
 
 Features:

--- a/spec/integration/edge_gateway/configure_nat_spec.rb
+++ b/spec/integration/edge_gateway/configure_nat_spec.rb
@@ -48,14 +48,13 @@ module Vcloud
         end
 
         it "should only make one EdgeGateway update task, to minimise EdgeGateway reload events" do
-          start_time = Time.now.getutc
-          task_list_before_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
+          last_task = IntegrationHelper.get_last_task(@test_params.edge_gateway)
           diff = EdgeGateway::Configure.new(@initial_nat_config_file, @vars_config_file).update
-          task_list_after_update = get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(start_time)
+          tasks_elapsed = IntegrationHelper.get_tasks_since(@test_params.edge_gateway, last_task)
 
           expect(diff.keys).to eq([:NatService])
           expect(diff[:NatService]).to have_at_least(1).items
-          expect(task_list_after_update.size - task_list_before_update.size).to be(1)
+          expect(tasks_elapsed).to have(1).items
         end
 
         it "should have configured at least one NAT rule" do
@@ -187,16 +186,6 @@ module Vcloud
           :original_ip => @test_params.provider_network_ip,
         }
       end
-
-      def get_all_edge_gateway_update_tasks_ordered_by_start_date_since_time(timestamp)
-        vcloud_time = timestamp.strftime('%FT%T.000Z')
-        q = Vcloud::Core::QueryRunner.new
-        q.run('task',
-          :filter => "name==networkConfigureEdgeGatewayServices;objectName==#{@test_params.edge_gateway};startDate=ge=#{vcloud_time}",
-          :sortDesc => 'startDate',
-        )
-      end
-
     end
 
   end

--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -13,5 +13,27 @@ module IntegrationHelper
     }
   end
 
+  def self.get_last_task(gateway_name)
+    tasks = Vcloud::Core::QueryRunner.new.run('task',
+      :filter   => "name==networkConfigureEdgeGatewayServices;" + \
+                   "objectName==#{gateway_name}",
+      :sortDesc => 'startDate',
+      :pageSize => 1,
+    )
 
+    raise "Unable to find last vCloud task" if tasks.empty?
+    tasks.first
+  end
+
+  def self.get_tasks_since(gateway_name, task)
+    tasks = Vcloud::Core::QueryRunner.new.run('task',
+      :filter   => "name==networkConfigureEdgeGatewayServices;" + \
+                   "objectName==#{gateway_name};" + \
+                   "startDate=ge=#{task.fetch(:startDate)}",
+      :sortDesc => 'startDate',
+    )
+
+    tasks.reject! { |t| t.fetch(:href) == task.fetch(:href) }
+    tasks
+  end
 end

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 0.13.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.14.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Integration tests which confirm atomicity and idempotency of updates by
checking the number of tasks generated during an operation were sensitive to
time differences between the clocks on the local machine and vCloud
Director.

This could be reproduced by putting your local clock forward one hour. You'd
get a test failure like the following:

```
1) Vcloud::EdgeGatewayServices Test EdgeGatewayServices with multiple services Check update is functional should only create one edgeGateway update task when updating the configuration
   Failure/Error: expect(task_list_after_update.size - task_list_before_update.size).to be(1)

     expected #<Fixnum:3> => 1
          got #<Fixnum:1> => 0

     Compared using equal?, which compares object identity,
     but expected and actual are not the same object. Use
     `expect(actual).to eq(expected)` if you don't care about
     object identity in this example.
   # ./spec/integration/edge_gateway/edge_gateway_services_spec.rb:44:in `block (4 levels) in <module:Vcloud>'
```

This is because it was using the local time to find all tasks that had
occurred since the beginning of that test and vCloud Director didn't know of
any tasks that had occurred in (what it considers to be) the future.

Fix this by using a previous Edge Gateway task as a marker and find all
tasks that have occurred since that. The timestamp of that last task is
generated by the clock available to vCloud Director, so any difference
between local and remote time is no longer an issue.

In most cases the previous task will be another one of our tests or the
`reset_edge_gateway` before block. The helper will raise an exception if
it's unable to find anything at all. We make sure _that_ task is removed
from the elapsed results by matching it's unique `href` field.

The option `pageSize 1` is used in the initial query to optimise the amount
of data we get from vCloud, because we only care about the single most
recent. This depends on a new release of vcloud-core for
gds-operations/vcloud-core#140 - without which it will fetch all results
one-by-one, very slowly.

---

Tests will fail until vcloud-core is merged/released.
