### PR TITLE
Bump vCloud Core and release version 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.5.1 (2015-03-30)
+
+Bugfixes:
+
+  - Upgrade vCloud Core dependency to version 1.0.2 to pull in fix for this
+    error:
+
+        undefined method `redisplay_progressbar' for Fog::Formatador:Class
+
 ## 1.5.0 (2015-03-04)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ Bugfixes:
 ## 1.5.0 (2015-03-04)
 
 Features:
+
   - Add support for static routes, thanks @geriBatai!
 
 Documentation:
+
   - Correct the Copyright notice
   - Guide for integration tests moved to GDS Operations web site
 

--- a/lib/vcloud/edge_gateway/version.rb
+++ b/lib/vcloud/edge_gateway/version.rb
@@ -1,6 +1,6 @@
 module Vcloud
   module EdgeGateway
-    VERSION = '1.5.0'
+    VERSION = '1.5.1'
   end
 end
 

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 1.0.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 1.0.2'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Upgrade vcloud-core dependency to version 1.0.2 to prevent this error from occurring:

    undefined method `redisplay_progressbar' for Fog::Formatador:Class