### PR TITLE
Ensure .ruby-version is respected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 ---
+sudo: false
 language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - 2.1.2
 notifications:
   email: false

--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -8,6 +8,8 @@ function cleanup {
   unset FOG_RC
 }
 
+export RBENV_VERSION="2.1.0"
+
 export FOG_RC=$(mktemp /tmp/vcloud_fog_rc.XXXXXXXXXX)
 trap cleanup EXIT
 


### PR DESCRIPTION
Reverts ffa3c35 to ensure that the .ruby-version file is respected now that
there is no longer a system version of Ruby installed on the slaves.