### PR TITLE
Bump vcloud-core version to 1.2.0.

### DIFF
--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 1.1.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 1.2.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
We need to pull in new cloud-core, which requires
a new fog version, which has functionality we need
in vcloud-edge-gateway.

https://github.com/gds-operations/vcloud-core/pull/177