### PR TITLE
[#91921114] Explicitly set Ruby version for Jenkins tests

### DIFF
--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -18,6 +18,8 @@ ${FOG_CREDENTIAL}:
   vcloud_director_password: ''
 EOF
 
+export RBENV_VERSION="2.1.2"
+
 git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec rake


### PR DESCRIPTION
Set the `RBENV_VERSION` environment variable so that our Jenkins tests
run under Ruby version 2.1.2, the latest version supported by our
`travis.yml` which is used to run the spec tests.

Prior to this, Jenkins would implicitly use the system ruby version
(1.9.3) to run the tests.