### PR TITLE
[#91921114] Change raise_error assertion to match using regex

### DIFF
--- a/spec/integration/edge_gateway/configure_load_balancer_spec.rb
+++ b/spec/integration/edge_gateway/configure_load_balancer_spec.rb
@@ -138,7 +138,7 @@ module Vcloud
           config_file = IntegrationHelper.fixture_file('load_balancer_single_virtual_server_invalid_pool.yaml.mustache')
           expect { EdgeGateway::Configure.new(config_file, @vars_config_file).update }.
             to raise_error(
-              'Load balancer virtual server integration-test-vs-1 does not have a valid backing pool.'
+              /Load balancer virtual server integration-test-vs-1 does not have a valid backing pool/
             )
         end
 


### PR DESCRIPTION
This test was failing with:

    1) Vcloud::EdgeGateway::Configure Test LoadBalancerService specifics Check specific LoadBalancerService update cases should raise an error when trying configure with a single VirtualServer, with an unconfigured pool
      Failure/Error: expect { EdgeGateway::Configure.new(config_file, @vars_config_file).update }.
        expected Exception with "Load balancer virtual server integration-test-vs-1 does not have a valid backing pool.", got #<Fog::Compute::VcloudDirector::BadRequest: [ e9175391-1b5e-4ce1-af0f-6bc1c030e4c9 ] Load balancer virtual server integration-test-vs-1 does not have a valid backing pool.> with backtrace:
          # ./lib/vcloud/edge_gateway/configure.rb:25:in `update'
          # ./spec/integration/edge_gateway/configure_load_balancer_spec.rb:139:in `block (5 levels) in <module:Vcloud>'
          # ./spec/integration/edge_gateway/configure_load_balancer_spec.rb:139:in `block (4 levels) in <module:Vcloud>'
      # ./spec/integration/edge_gateway/configure_load_balancer_spec.rb:139:in `block (4 levels) in <module:Vcloud>'

The expected exception was raised, however the error message was
prefixed with a UUID. Match the error message using a regular expression
so that the presence of the UUID does not cause the test to fail.