### PR TITLE
[#91921114] Move RBENV_VERSION to its own file and source it in jenkins.sh

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,4 +2,6 @@
 set -e
 
 ./jenkins_tests.sh
+
+source ./rbenv_version.sh
 bundle exec rake publish_gem

--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -18,7 +18,7 @@ ${FOG_CREDENTIAL}:
   vcloud_director_password: ''
 EOF
 
-export RBENV_VERSION="2.1.2"
+source ./rbenv_version.sh
 
 git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"

--- a/rbenv_version.sh
+++ b/rbenv_version.sh
@@ -1,0 +1,1 @@
+export RBENV_VERSION="2.1.2"


### PR DESCRIPTION
Set `RBENV_VERSION` by sourcing `./rbenv_version.sh` before invoking
Rake to prevent the `bundle` command from failing because no Ruby
version is set.

It's necessary to source `./rbenv_version.sh` in both `jenkins.sh` and
`jenkins_tests.sh` because we run the former in Carrenza but the latter
in Skyscape; we only publish the gem once the tests have passed for both
suppliers.