### PR TITLE
[#91921114] Remove support for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
 notifications:

--- a/rbenv_version.sh
+++ b/rbenv_version.sh
@@ -1,1 +1,1 @@
-export RBENV_VERSION="2.1.2"
+export RBENV_VERSION="2.0.0"


### PR DESCRIPTION
Ruby 1.9.3 is end-of-life as of February 23, 2015, and we've removed
support for it from vcloud-core:

gds-operations/vcloud-core@1a26f58

* * *

Also, make run our integration tests using the oldest Ruby version we
support, version 2.0.0, as that version is the most likely to highlight
breaking changes, for example if gems we're dependent on stop supporting
version 2.0.x.