### PR TITLE
[#91921114] Run Travis tests against Ruby 2.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1.2
+  - 2.2.3
 notifications:
   email: false
 sudo: false


### PR DESCRIPTION
Ruby 2.2.3 is the latest release in the Ruby 2.2.x branch.