### PR TITLE
Upgrade Ruby version from 2.0.0 to 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.2
+  - 2.1.7
 notifications:
   email: false

--- a/rbenv_version.sh
+++ b/rbenv_version.sh
@@ -1,1 +1,1 @@
-export RBENV_VERSION="2.0.0"
+export RBENV_VERSION="2.1"


### PR DESCRIPTION
Ruby 2.0.0 is [no longer installed on the CI servers][1]. The [next available version is 2.1][2] (which is an alias to 2.1.7).

Also amend the Travis configuration to use this newer version of the 2.1 release.

[1]: https://github.com/alphagov/ci-puppet/commit/de97578cab18816a9cd1aeba10e796cf10eb0649
[2]: https://github.com/alphagov/ci-puppet/blob/993b4b5f901b7d497181b34175653929bdfbbfd6/modules/ci_environment/manifests/base.pp#L72-L74