### PR TITLE
Add description for nat rules

### DIFF
--- a/lib/vcloud/edge_gateway/configuration_generator/nat_service.rb
+++ b/lib/vcloud/edge_gateway/configuration_generator/nat_service.rb
@@ -25,6 +25,7 @@ module Vcloud
             new_rule[:Id] = rule.key?(:id) ? rule[:id] : i.to_s
             new_rule[:IsEnabled] = rule.key?(:enabled) ? rule[:enabled].to_s : 'true'
             new_rule[:RuleType] = rule[:rule_type]
+            new_rule[:Description] = rule[:description] if rule.key?(:description)
             gateway_nat_rule = populate_gateway_nat_rule(rule)
             new_rule[:GatewayNatRule] = gateway_nat_rule
             i += 1

--- a/spec/integration/edge_gateway/configure_nat_spec.rb
+++ b/spec/integration/edge_gateway/configure_nat_spec.rb
@@ -97,6 +97,7 @@ module Vcloud
           expect(dnat_rule).not_to be_nil
           expect(dnat_rule[:RuleType]).to eq('DNAT')
           expect(dnat_rule[:Id]).to eq('65537')
+          expect(dnat_rule[:Description]).to eq('Example DNAT')
           expect(dnat_rule[:IsEnabled]).to eq('true')
           expect(dnat_rule[:GatewayNatRule][:Interface][:href]).to include(@test_params.provider_network_id)
           expect(dnat_rule[:GatewayNatRule][:OriginalIp]).to eq(@test_params.provider_network_ip)
@@ -113,6 +114,7 @@ module Vcloud
           expect(snat_rule).not_to be_nil
           expect(snat_rule[:RuleType]).to eq('SNAT')
           expect(snat_rule[:Id]).to eq('65538')
+          expect(snat_rule[:Description]).to eq('Example SNAT')
           expect(snat_rule[:IsEnabled]).to eq('true')
           expect(snat_rule[:GatewayNatRule][:Interface][:href]).to include(@test_params.provider_network_id)
           expect(snat_rule[:GatewayNatRule][:OriginalIp]).to eq('10.10.1.2-10.10.1.3')
@@ -144,6 +146,7 @@ module Vcloud
           expect(expected_rule).not_to be_nil
           expect(expected_rule[:RuleType]).to eq('DNAT')
           expect(expected_rule[:Id]).to eq('65537')
+          expect(dnat_rule[:Description]).to eq('Example DNAT')
           expect(expected_rule[:RuleType]).to eq('DNAT')
           expect(expected_rule[:IsEnabled]).to eq('true')
           expect(expected_rule[:GatewayNatRule][:Interface][:name]).to eq(@test_params.network_1)

--- a/spec/integration/edge_gateway/data/nat_config.yaml.mustache
+++ b/spec/integration/edge_gateway/data/nat_config.yaml.mustache
@@ -5,6 +5,7 @@ nat_service:
   - enabled: true
     network_id: {{ network_id }}
     rule_type: 'DNAT'
+    decription: 'Example DNAT'
     translated_ip: '10.10.1.2-10.10.1.3'
     translated_port: '3412'
     original_ip: {{ original_ip }}
@@ -13,5 +14,6 @@ nat_service:
   - enabled: true
     network_id: {{ network_id }}
     rule_type: 'SNAT'
+    description: 'Example SNAT'
     translated_ip: {{ original_ip }}
     original_ip: '10.10.1.2-10.10.1.3'

--- a/spec/vcloud/edge_gateway/configuration_generator/nat_service_spec.rb
+++ b/spec/vcloud/edge_gateway/configuration_generator/nat_service_spec.rb
@@ -26,6 +26,7 @@ module Vcloud
 
           before(:each) do
             input = { nat_rules: [{
+              description: 'Default Outbound',
               rule_type: 'SNAT',
               network_id: '2ad93597-7b54-43dd-9eb1-631dd337e5a7',
               original_ip: "192.0.2.2",
@@ -43,6 +44,10 @@ module Vcloud
             expect(@rule[:RuleType]).to eq('SNAT')
           end
 
+          it 'should have a Description of Default Outbound' do
+            expect(@rule[:Description]).to eq('Default Outbound')
+          end
+
           it 'should not include a Protocol' do
             expect(@rule[:GatewayNatRule].key?(:Protocol)).to be_false
           end
@@ -52,6 +57,7 @@ module Vcloud
               :Id=>"#{@base_nat_id}",
               :IsEnabled=>"true",
               :RuleType=>"SNAT",
+              :Description=>"Default Outbound",
               :GatewayNatRule=>{
                 :Interface=>{
                   :type => 'application/vnd.vmware.admin.network+xml',
@@ -70,6 +76,7 @@ module Vcloud
           before(:each) do
             input = { nat_rules: [{
               rule_type: 'DNAT',
+              description: 'Default Inbound',
               network_id: '2ad93597-7b54-43dd-9eb1-631dd337e5a7',
               original_ip: "192.0.2.2",
               original_port: '22',
@@ -89,6 +96,10 @@ module Vcloud
             expect(@rule[:RuleType]).to eq('DNAT')
           end
 
+          it 'should have a Decription of Default Inbound' do
+            expect(@rule[:Description]).to eq('Default Inbound')
+          end
+
           it 'should include a default Protocol of tcp' do
             expect(@rule[:GatewayNatRule][:Protocol]).to eq('tcp')
           end
@@ -98,6 +109,7 @@ module Vcloud
               :Id=>"#{@base_nat_id}",
               :IsEnabled=>"true",
               :RuleType=>"DNAT",
+              :Description=>"Default Inbound",
               :GatewayNatRule=>{
                 :Interface=>{
                   :type => 'application/vnd.vmware.admin.network+xml',


### PR DESCRIPTION
Add in the ability to add descriptions for NAT rules which is particularly useful considering the external-to-internal nature of DNAT rules.

This was raised here: https://github.com/gds-operations/vcloud-edge_gateway/issues/126