### PR TITLE
Update dependencies for vcloud-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
   - 2.1.2
 notifications:
   email: false
+sudo: false

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 1.2.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 2.0.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.23.0'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
-  s.add_development_dependency 'vcloud-tools-tester', '~> 1.0.0'
+  s.add_development_dependency 'vcloud-tools-tester'
 end
 


### PR DESCRIPTION
vcloud-core has recently been updated to 2.0.0. This updates the dependency, and also releases the dependency for vcloud-tools-tester (which is linked to core).