### PR TITLE
Fixes Load balancing algorithm options

### DIFF
--- a/lib/vcloud/edge_gateway/schema/load_balancer_service.rb
+++ b/lib/vcloud/edge_gateway/schema/load_balancer_service.rb
@@ -36,7 +36,7 @@ module Vcloud
           enabled: { type: 'boolean', required: false },
           port:    { type: 'string_or_number', required: false },
           algorithm: { type: 'enum', required: false,
-            acceptable_values: [ 'ROUND_ROBIN', 'IP_HASH', 'URI', 'LEAST_CONNECTED' ]},
+            acceptable_values: [ 'ROUND_ROBIN', 'IP_HASH', 'URI', 'LEAST_CONN' ]},
           health_check: {
             type: 'hash',
             required: false,


### PR DESCRIPTION
This makes it in line with
https://pubs.vmware.com/vca/index.jsp#com.vmware.vcloud.api.doc_56/GUID-AC9C1385-0CDC-45E1-81DA-7AED16D598B0.html

The change is LEAST_CONNECTED to LEAST_CONN

See #148 