### PR TITLE
Pin nokogiri version.

### DIFF
--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -24,11 +24,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'vcloud-core', '~> 2.0.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '~> 10.0.0'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubocop', '~> 0.23.0'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
+  s.add_development_dependency 'nokogiri', '~> 1.6.0'
   s.add_development_dependency 'vcloud-tools-tester'
 end
 


### PR DESCRIPTION
Versions newer than this fail on the version of ruby we're running our tests under.