### PR TITLE
Update rubocop

### DIFF
--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 10.0.0'
   s.add_development_dependency 'rspec', '~> 2.14.1'
-  s.add_development_dependency 'rubocop', '~> 0.23.0'
+  s.add_development_dependency 'rubocop', '~> 0.49.1'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'nokogiri', '~> 1.6.0'


### PR DESCRIPTION
Rubocop needs updating to work with later versions of Ruby.