### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.0 (2017-06-22)
+
+  - Upgrade to the latest vCloud Core, and bring the version number into line
+    with the rest of the toolset.
+  - Remove support for Ruby versions older than 2.2.2.
+  - Add support for Ruby 2.3.0 and 2.4.0.
+  - Upgrade Rspec, Rubocop, Simplecov and Rake.
+  - Add documentation regarding deprecation of support
+  - Various bug fixes
+
 ## Unreleased
 
 - Remove support for Ruby 1.9.3, which is now end-of-life.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
 
     if (env.BRANCH_NAME == "master") {
       stage("Publish gem") {
-        sh('bundle exec rake publish_gem')
+        govuk.publishGem(repoName, env.BRANCH_NAME)
       }
     }
   } catch (e) {

--- a/lib/vcloud/edge_gateway/version.rb
+++ b/lib/vcloud/edge_gateway/version.rb
@@ -1,6 +1,6 @@
 module Vcloud
   module EdgeGateway
-    VERSION = '1.5.2'
+    VERSION = '2.1.0'
   end
 end
 

--- a/spec/integration/edge_gateway/configure_firewall_spec.rb
+++ b/spec/integration/edge_gateway/configure_firewall_spec.rb
@@ -39,7 +39,7 @@ module Vcloud
 
         it "should be starting our tests from an empty firewall" do
           remote_vcloud_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration][:FirewallService]
-          expect(remote_vcloud_config[:FirewallRule].empty?).to be_true
+          expect(remote_vcloud_config[:FirewallRule].empty?).to be true
         end
 
         it "should only need to make one call to Core::EdgeGateway.update_configuration" do
@@ -52,7 +52,7 @@ module Vcloud
 
         it "should have configured at least one firewall rule" do
           remote_vcloud_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration][:FirewallService]
-          expect(remote_vcloud_config[:FirewallRule].empty?).to be_false
+          expect(remote_vcloud_config[:FirewallRule].empty?).to be false
         end
 
         it "should have configured the same number of firewall rules as in our configuration" do

--- a/spec/integration/edge_gateway/configure_load_balancer_spec.rb
+++ b/spec/integration/edge_gateway/configure_load_balancer_spec.rb
@@ -41,8 +41,8 @@ module Vcloud
         it "should be starting our tests from an empty LoadBalancerService" do
           edge_service_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
           remote_vcloud_config = edge_service_config[:LoadBalancerService]
-          expect(remote_vcloud_config[:Pool].empty?).to be_true
-          expect(remote_vcloud_config[:VirtualServer].empty?).to be_true
+          expect(remote_vcloud_config[:Pool].empty?).to be true
+          expect(remote_vcloud_config[:VirtualServer].empty?).to be true
         end
 
         it "should only make one EdgeGateway update task, to minimise EdgeGateway reload events" do
@@ -62,7 +62,7 @@ module Vcloud
 
           edge_service_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
           remote_vcloud_config = edge_service_config[:LoadBalancerService]
-          expect(remote_vcloud_config[:Pool].empty?).to be_false
+          expect(remote_vcloud_config[:Pool].empty?).to be false
         end
 
         it "should have configured at least one LoadBancer VirtualServer entry" do
@@ -70,7 +70,7 @@ module Vcloud
 
           edge_service_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
           remote_vcloud_config = edge_service_config[:LoadBalancerService]
-          expect(remote_vcloud_config[:VirtualServer].empty?).to be_false
+          expect(remote_vcloud_config[:VirtualServer].empty?).to be false
         end
 
         it "should have configured the same number of Pools as in our configuration" do

--- a/spec/integration/edge_gateway/configure_multiple_services_spec.rb
+++ b/spec/integration/edge_gateway/configure_multiple_services_spec.rb
@@ -30,10 +30,10 @@ module Vcloud
 
         it "should be starting our tests from an empty EdgeGateway" do
           remote_vcloud_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
-          expect(remote_vcloud_config[:FirewallService][:FirewallRule].empty?).to be_true
-          expect(remote_vcloud_config[:NatService][:NatRule].empty?).to be_true
-          expect(remote_vcloud_config[:LoadBalancerService][:Pool].empty?).to be_true
-          expect(remote_vcloud_config[:LoadBalancerService][:VirtualServer].empty?).to be_true
+          expect(remote_vcloud_config[:FirewallService][:FirewallRule].empty?).to be true
+          expect(remote_vcloud_config[:NatService][:NatRule].empty?).to be true
+          expect(remote_vcloud_config[:LoadBalancerService][:Pool].empty?).to be true
+          expect(remote_vcloud_config[:LoadBalancerService][:VirtualServer].empty?).to be true
         end
 
         it "should only create one edgeGateway update task when updating the configuration" do
@@ -53,8 +53,8 @@ module Vcloud
           pending("This test will fail until https://github.com/fog/fog/pull/3695 is merged and released by Fog")
 
           remote_vcloud_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
-          expect(remote_vcloud_config[:FirewallService][:FirewallRule].empty?).to be_false
-          expect(remote_vcloud_config[:NatService][:NatRule].empty?).to be_false
+          expect(remote_vcloud_config[:FirewallService][:FirewallRule].empty?).to be false
+          expect(remote_vcloud_config[:NatService][:NatRule].empty?).to be false
           expect(remote_vcloud_config[:LoadBalancerService][:Pool].empty?).to be(true)
           expect(remote_vcloud_config[:LoadBalancerService][:VirtualServer].empty?).to be(true)
         end

--- a/spec/integration/edge_gateway/configure_nat_spec.rb
+++ b/spec/integration/edge_gateway/configure_nat_spec.rb
@@ -44,7 +44,7 @@ module Vcloud
 
         it "should be starting our tests from an empty NatService" do
           remote_vcloud_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration][:NatService]
-          expect(remote_vcloud_config[:NatRule].empty?).to be_true
+          expect(remote_vcloud_config[:NatRule].empty?).to be true
         end
 
         it "should only make one EdgeGateway update task, to minimise EdgeGateway reload events" do
@@ -63,7 +63,7 @@ module Vcloud
           pending("This test will fail until https://github.com/fog/fog/pull/3695 is merged and released by Fog")
 
           remote_vcloud_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration][:NatService]
-          expect(remote_vcloud_config[:NatRule].empty?).to be_false
+          expect(remote_vcloud_config[:NatRule].empty?).to be false
         end
 
         it "should have configured the same number of nat rules as in our configuration" do

--- a/spec/integration/edge_gateway/configure_static_routing_spec.rb
+++ b/spec/integration/edge_gateway/configure_static_routing_spec.rb
@@ -43,7 +43,7 @@ module Vcloud
           edge_service_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
           remote_vcloud_config = edge_service_config[:StaticRoutingService]
           if remote_vcloud_config
-            expect(remote_vcloud_config[:StaticRoute].nil?).to be_true
+            expect(remote_vcloud_config[:StaticRoute].nil?).to be true
           end
         end
 
@@ -61,7 +61,7 @@ module Vcloud
         it "should have configured at least one static route" do
           edge_service_config = @edge_gateway.vcloud_attributes[:Configuration][:EdgeGatewayServiceConfiguration]
           remote_vcloud_config = edge_service_config[:StaticRoutingService]
-          expect(remote_vcloud_config[:StaticRoute].empty?).to be_false
+          expect(remote_vcloud_config[:StaticRoute].empty?).to be false
         end
 
         it "should have configured the same number of static routes as in our configuration" do
@@ -92,7 +92,7 @@ module Vcloud
 
           expect(diff.keys).to eq([:StaticRoutingService])
           expect(diff[:StaticRoutingService]).to have_at_least(1).items
-          expect(remote_vcloud_config[:StaticRoute].nil?).to be_true
+          expect(remote_vcloud_config[:StaticRoute].nil?).to be true
         end
 
       end

--- a/spec/vcloud/edge_gateway/configuration_generator/load_balancer_service_spec.rb
+++ b/spec/vcloud/edge_gateway/configuration_generator/load_balancer_service_spec.rb
@@ -111,7 +111,7 @@ module Vcloud
           end
 
           it 'should default to description being not set' do
-            expect(@rule.key?(:Description)).to be_false
+            expect(@rule.key?(:Description)).to be false
           end
 
           it 'should match our expected complete entry' do

--- a/spec/vcloud/edge_gateway/configuration_generator/nat_service_spec.rb
+++ b/spec/vcloud/edge_gateway/configuration_generator/nat_service_spec.rb
@@ -49,7 +49,7 @@ module Vcloud
           end
 
           it 'should not include a Protocol' do
-            expect(@rule[:GatewayNatRule].key?(:Protocol)).to be_false
+            expect(@rule[:GatewayNatRule].key?(:Protocol)).to be false
           end
 
           it 'should completely match our expected default rule' do

--- a/spec/vcloud/edge_gateway/edge_gateway_configuration_spec.rb
+++ b/spec/vcloud/edge_gateway/edge_gateway_configuration_spec.rb
@@ -42,7 +42,7 @@ module Vcloud
 
         it "if `config` is called before `update_required` then config is not empty when it shouldn't be" do
           config = @proposed_config.config
-          expect(config.empty?).to be_false
+          expect(config.empty?).to be false
         end
 
       end
@@ -97,10 +97,10 @@ module Vcloud
         it "proposed diff contains changes for all services" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:FirewallService, :NatService, :GatewayIpsecVpnService, :LoadBalancerService])
-          expect(diff[:FirewallService]).to        have_at_least(1).items
-          expect(diff[:NatService]).to             have_at_least(1).items
-          expect(diff[:GatewayIpsecVpnService]).to have_at_least(1).items
-          expect(diff[:LoadBalancerService]).to    have_at_least(1).items
+          expect(diff[:FirewallService].size).to        be >= 1
+          expect(diff[:NatService].size).to             be >= 1
+          expect(diff[:GatewayIpsecVpnService].size).to be >= 1
+          expect(diff[:LoadBalancerService].size).to    be >= 1
         end
 
       end
@@ -144,7 +144,7 @@ module Vcloud
         it "proposed diff contains changes for firewall service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:FirewallService])
-          expect(diff[:FirewallService]).to have_at_least(1).items
+          expect(diff[:FirewallService].size).to be >= 1
         end
 
       end
@@ -195,7 +195,7 @@ module Vcloud
         it "proposed diff contains changes for firewall and VPN service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:FirewallService, :GatewayIpsecVpnService])
-          expect(diff[:FirewallService]).to have_at_least(1).items
+          expect(diff[:FirewallService].size).to be >= 1
         end
 
       end
@@ -241,7 +241,7 @@ module Vcloud
         it "proposed diff contains changes for load balancer service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:LoadBalancerService])
-          expect(diff[:LoadBalancerService]).to have_at_least(1).items
+          expect(diff[:LoadBalancerService].size).to be >= 1
         end
 
       end
@@ -288,8 +288,8 @@ module Vcloud
         it "proposed diff contains changes for firewall and load balancer services" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:FirewallService, :LoadBalancerService])
-          expect(diff[:FirewallService]).to     have_at_least(1).items
-          expect(diff[:LoadBalancerService]).to have_at_least(1).items
+          expect(diff[:FirewallService].size).to     be >= 1
+          expect(diff[:LoadBalancerService].size).to be >= 1
         end
 
       end
@@ -334,7 +334,7 @@ module Vcloud
         it "proposed diff contains changes for load balancer service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:LoadBalancerService])
-          expect(diff[:LoadBalancerService]).to have_at_least(1).items
+          expect(diff[:LoadBalancerService].size).to be >= 1
         end
 
       end
@@ -479,7 +479,7 @@ module Vcloud
         it "proposed diff contains changes for nat service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:NatService])
-          expect(diff[:NatService]).to have_at_least(1).items
+          expect(diff[:NatService].size).to be >= 1
         end
 
       end
@@ -522,7 +522,7 @@ module Vcloud
         it "proposed diff contains changes for firewall service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:FirewallService])
-          expect(diff[:FirewallService]).to have_at_least(1).items
+          expect(diff[:FirewallService].size).to be >= 1
         end
 
       end
@@ -565,7 +565,7 @@ module Vcloud
         it "proposed diff contains changes for nat service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:NatService])
-          expect(diff[:NatService]).to have_at_least(1).items
+          expect(diff[:NatService].size).to be >= 1
         end
 
       end
@@ -612,7 +612,7 @@ module Vcloud
         it "proposed diff contains changes for load balancer service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:LoadBalancerService])
-          expect(diff[:LoadBalancerService]).to have_at_least(1).items
+          expect(diff[:LoadBalancerService].size).to be >= 1
         end
 
       end
@@ -655,7 +655,7 @@ module Vcloud
         it "proposed diff contains changes for VPN service" do
           diff = @proposed_config.diff
           expect(diff.keys).to eq([:GatewayIpsecVpnService])
-          expect(diff[:GatewayIpsecVpnService]).to have_at_least(1).items
+          expect(diff[:GatewayIpsecVpnService].size).to be >= 1
         end
 
       end

--- a/spec/vcloud/edge_gateway/firewall_schema_validation_spec.rb
+++ b/spec/vcloud/edge_gateway/firewall_schema_validation_spec.rb
@@ -17,7 +17,7 @@ module Vcloud
 
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, config, Vcloud::EdgeGateway::Schema::FIREWALL_SERVICE)
-        expect(validator.valid?).to be_false
+        expect(validator.valid?).to be false
         expect(validator.errors).to eq([
                                          "source_ip: 192.0 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'.",
                                          "destination_ip: 10.10 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."
@@ -38,7 +38,7 @@ module Vcloud
 
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, config, Vcloud::EdgeGateway::Schema::FIREWALL_SERVICE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
     end
   end

--- a/spec/vcloud/edge_gateway/load_balancer_schema_validation_spec.rb
+++ b/spec/vcloud/edge_gateway/load_balancer_schema_validation_spec.rb
@@ -56,7 +56,7 @@ module Vcloud
           validator = Vcloud::Core::ConfigValidator.validate(:base, test[:input],
               Vcloud::EdgeGateway::Schema::LOAD_BALANCER_POOL_ENTRY)
           expect(validator.errors).to eq([])
-          expect(validator.valid?).to be_true
+          expect(validator.valid?).to be true
         end
       end
 
@@ -96,7 +96,7 @@ module Vcloud
           validator = Vcloud::Core::ConfigValidator.validate(:base, test[:input],
               Vcloud::EdgeGateway::Schema::LOAD_BALANCER_VIRTUAL_SERVER_ENTRY)
           expect(validator.errors).to eq([])
-          expect(validator.valid?).to be_true
+          expect(validator.valid?).to be true
         end
       end
 
@@ -122,7 +122,7 @@ module Vcloud
         validator = Vcloud::Core::ConfigValidator.validate(:base, input,
           Vcloud::EdgeGateway::Schema::LOAD_BALANCER_VIRTUAL_SERVER_ENTRY)
         expect(validator.errors).to eq([])
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
       it "does not validate a virtual_server entry with a COOKIE http " +
@@ -149,7 +149,7 @@ module Vcloud
           "persistence: missing 'cookie_name' parameter",
           "persistence: missing 'cookie_mode' parameter",
         ])
-        expect(validator.valid?).to be_false
+        expect(validator.valid?).to be false
       end
 
       it "validates a virtual_server entry with a SSL_SESSION_ID https persistence method" do
@@ -172,7 +172,7 @@ module Vcloud
         validator = Vcloud::Core::ConfigValidator.validate(:base, input,
           Vcloud::EdgeGateway::Schema::LOAD_BALANCER_VIRTUAL_SERVER_ENTRY)
         expect(validator.errors).to eq([])
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
       it "validates a virtual_server entry with a tcp service_profile" do
@@ -192,7 +192,7 @@ module Vcloud
         validator = Vcloud::Core::ConfigValidator.validate(:base, input,
           Vcloud::EdgeGateway::Schema::LOAD_BALANCER_VIRTUAL_SERVER_ENTRY)
         expect(validator.errors).to eq([])
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
       it "does not validate a virtual_server tcp service_profile with a persistence section" do
@@ -213,7 +213,7 @@ module Vcloud
         validator = Vcloud::Core::ConfigValidator.validate(:base, input,
           Vcloud::EdgeGateway::Schema::LOAD_BALANCER_VIRTUAL_SERVER_ENTRY)
         expect(validator.errors).to eq(["tcp: parameter 'persistence' is invalid"])
-        expect(validator.valid?).to be_false
+        expect(validator.valid?).to be false
       end
 
     end
@@ -242,7 +242,7 @@ module Vcloud
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, input, Vcloud::EdgeGateway::Schema::LOAD_BALANCER_SERVICE)
         expect(validator.errors).to eq([])
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
       it "should validate ok if an empty pool service section is provided" do
@@ -262,7 +262,7 @@ module Vcloud
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, input, Vcloud::EdgeGateway::Schema::LOAD_BALANCER_SERVICE)
         expect(validator.errors).to eq([])
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
       it "should validate ok if an empty virtual_server service_profile section is provided" do
@@ -284,7 +284,7 @@ module Vcloud
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, input, Vcloud::EdgeGateway::Schema::LOAD_BALANCER_SERVICE)
         expect(validator.errors).to eq([])
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
       it "should be ok if no pools are specified" do
@@ -292,7 +292,7 @@ module Vcloud
           virtual_servers: []
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, input, Vcloud::EdgeGateway::Schema::LOAD_BALANCER_SERVICE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
       it "should be ok if no virtual_servers are specified" do
@@ -300,7 +300,7 @@ module Vcloud
           pools: []
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, input, Vcloud::EdgeGateway::Schema::LOAD_BALANCER_SERVICE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
 
     end

--- a/spec/vcloud/edge_gateway/nat_schema_validation_spec.rb
+++ b/spec/vcloud/edge_gateway/nat_schema_validation_spec.rb
@@ -14,7 +14,7 @@ module Vcloud
 
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, snat_rule, Vcloud::EdgeGateway::Schema::NAT_RULE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
         expect(validator.errors).to be_empty
 
       end
@@ -34,7 +34,7 @@ module Vcloud
           it "should error since mandatory field #{mandatory_field} is missing" do
             @snat_rule.delete(mandatory_field)
             validator = Vcloud::Core::ConfigValidator.validate(:base, @snat_rule, Vcloud::EdgeGateway::Schema::NAT_RULE)
-            expect(validator.valid?).to be_false
+            expect(validator.valid?).to be false
             expect(validator.errors).to eq(["base: missing '#{mandatory_field}' parameter"])
           end
         end
@@ -53,7 +53,7 @@ module Vcloud
 
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, snat_rule, Vcloud::EdgeGateway::Schema::NAT_RULE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
         expect(validator.errors).to be_empty
       end
     end
@@ -85,7 +85,7 @@ module Vcloud
           ]
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, nat_service, Vcloud::EdgeGateway::Schema::NAT_SERVICE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
         expect(validator.errors).to be_empty
       end
     end

--- a/spec/vcloud/edge_gateway/static_routing_schema_validation_spec.rb
+++ b/spec/vcloud/edge_gateway/static_routing_schema_validation_spec.rb
@@ -15,7 +15,7 @@ module Vcloud
           ]
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, config, Vcloud::EdgeGateway::Schema::STATIC_ROUTING_SERVICE)
-        expect(validator.valid?).to be_false
+        expect(validator.valid?).to be false
         expect(validator.errors).to eq([
                                         "network: 10.10.10.10/256 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'.",
                                         "next_hop: 192.1 is not a valid ip_address",
@@ -34,7 +34,7 @@ module Vcloud
           ]
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, config, Vcloud::EdgeGateway::Schema::STATIC_ROUTING_SERVICE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
       end
     end
   end

--- a/spec/vcloud/edge_gateway/vpn_schema_validation_spec.rb
+++ b/spec/vcloud/edge_gateway/vpn_schema_validation_spec.rb
@@ -29,7 +29,7 @@ module Vcloud
           }]
         }
         validator = Vcloud::Core::ConfigValidator.validate(:base, vpn_tunnel, Vcloud::EdgeGateway::Schema::VPN_RULE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
         expect(validator.errors).to be_empty
 
       end
@@ -68,7 +68,7 @@ module Vcloud
           it "should error since mandatory field #{mandatory_field} is missing" do
             @vpn_tunnel.delete(mandatory_field)
             validator = Vcloud::Core::ConfigValidator.validate(:base, @vpn_tunnel, Vcloud::EdgeGateway::Schema::VPN_RULE)
-            expect(validator.valid?).to be_false
+            expect(validator.valid?).to be false
             expect(validator.errors).to eq(["base: missing '#{mandatory_field}' parameter"])
           end
         end
@@ -101,7 +101,7 @@ module Vcloud
           description: 'foobarbaz'
          }
         validator = Vcloud::Core::ConfigValidator.validate(:base, vpn_tunnel, Vcloud::EdgeGateway::Schema::VPN_RULE)
-        expect(validator.valid?).to be_true
+        expect(validator.valid?).to be true
         expect(validator.errors).to be_empty
       end
     end

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -21,15 +21,15 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 2.0.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 2.1.0'
   s.add_runtime_dependency 'hashdiff'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rake', '~> 10.0.0'
-  s.add_development_dependency 'rspec', '~> 2.14.1'
+  s.add_development_dependency 'rake', '>= 12'
+  s.add_development_dependency 'rspec', '>= 3.6 '
   s.add_development_dependency 'rubocop', '~> 0.49.1'
-  s.add_development_dependency 'simplecov', '~> 0.7.1'
+  s.add_development_dependency 'simplecov', '~> 0.14.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
-  s.add_development_dependency 'nokogiri', '~> 1.6.0'
-  s.add_development_dependency 'vcloud-tools-tester'
+  s.add_development_dependency 'nokogiri', '~> 1.6.8.1'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 2.1.0'
 end
 

--- a/vcloud-edge_gateway.gemspec
+++ b/vcloud-edge_gateway.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.2'
 
   s.add_runtime_dependency 'vcloud-core', '~> 2.1.0'
   s.add_runtime_dependency 'hashdiff'


### PR DESCRIPTION
Release 2.1.0 which is the first release in two years as the last change never got an official release. We therefore bring the version number into line with the rest of the tools.

Loads of bug fixes as I also upgraded rspec, rubocop and rake in this PR. 

https://trello.com/c/0uDbDpkt/574-update-dependencies-on-vcloud-tools

